### PR TITLE
Added -r xml and Jenkins instructions

### DIFF
--- a/haxe-checkstyle/hudsonandbamboo.md
+++ b/haxe-checkstyle/hudsonandbamboo.md
@@ -8,8 +8,14 @@ Checkstyle has `xml` report option that can be used to integrate with Hudson, Je
 If you want to style the generated XML you can set XSLT style for the XML generated. See the sample below.
 
 ```
-haxelib run checkstyle -s src -c config.json -p report.xml -x report.xsl
+haxelib run checkstyle -s src -c config.json -r xml -p report.xml -x report.xsl
 ```
+
+### Configure Jenkins
+
+You'll need the [Checkstyle Plugin](https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin) installed.
+
+Add the Post-build Action: "Publish Checkstyle analysis results" to ingest the generated `xml` report on your Jenkins job.
 
 ### Sample Trend Chart
 


### PR DESCRIPTION
Running checkstyle without the -r flag resulted in a plain text output file which the Jenkins plugin didn't understand. Setting the reporter to xml yields the correct result.